### PR TITLE
Added ssl curl option to fix bug on Windows (Apache or IIS) systems running PHP 5.2.

### DIFF
--- a/panda.php
+++ b/panda.php
@@ -87,6 +87,8 @@ class Panda {
         }
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);
         // curl_setopt($curl, CURLOPT_VERBOSE, 1);
+        
+        curl_setopt($curl, CURLOPT_SSL_VERIFYPEER, 0);
 
         $response = curl_exec($curl);
         curl_close($curl);


### PR DESCRIPTION
Added ssl curl option. On Windows (Apache or IIS) systems running PHP 5.2.x, the http_request() method would always return an empty response. Since the peer is always Panda Stream, it's not a big deal ignoring this verification.
