### PR TITLE
Wrap CURL error to make it look like API error

### DIFF
--- a/panda.php
+++ b/panda.php
@@ -93,7 +93,17 @@ class Panda {
         // curl_setopt($curl, CURLOPT_VERBOSE, 1);
 
         $response = curl_exec($curl);
+        $error_code = curl_errno($curl);
+        $error_message = curl_error($curl);
         curl_close($curl);
+
+        if ( $error_code != CURLE_OK ) {
+            return json_encode(array(
+                'error' => 'CURL_' . $error_code,
+                'message' => $error_message,
+            ));
+        }
+
         return $response;
     }
 


### PR DESCRIPTION
In cases, when there was a CURL error during API call it will be properly wrapped in JSON and returned back as API error (error code will be prefixed with `CURL_`). This way developer will clearly know that there was an error communicating with Panda API server.
