### PR TITLE
Fix HTTPS support

### DIFF
--- a/panda.php
+++ b/panda.php
@@ -86,7 +86,7 @@ class Panda {
         curl_setopt($curl, CURLOPT_CUSTOMREQUEST, $verb);
         curl_setopt($curl, CURLOPT_PORT, $this->api_port);
         if (defined('CURLOPT_PROTOCOLS')) {
-            curl_setopt($curl, CURLOPT_PROTOCOLS, CURLPROTO_HTTP);
+            curl_setopt($curl, CURLOPT_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
         }
 
         curl_setopt($curl, CURLOPT_RETURNTRANSFER, 1);


### PR DESCRIPTION
On systems that have `CURLOPT_PROTOCOLS` set, no HTTPS requests could be made. This was very unfortunate, because HTTPS was the default for this library.

Kudos to @Koniii for finding this bug!
